### PR TITLE
Properly escape butts to make them monospace in Slack

### DIFF
--- a/lib/lita/handlers/butt.rb
+++ b/lib/lita/handlers/butt.rb
@@ -8,14 +8,27 @@ module Lita
       def butt(response)
         groups = response.matches.first
         width = groups.first.size
-
-        bottom = '_' * width
-        butt = "(#{bottom})#{bottom})"
+        butt = make_butt width
 
         if groups.last == 's'
-          response.reply [butt, butt].join ' '
+          response.reply(escape([butt, butt].join(' ')))
         else
-          response.reply butt
+          response.reply(escape(butt))
+        end
+      end
+
+      def make_butt(width = 1)
+        bottom = '_' * width
+        "(#{bottom})#{bottom})"
+      end
+
+      # Properly escape the butt for a given chat service
+      def escape(butt, adapter = robot.config.robot.adapter)
+        case adapter
+        when :slack
+          "`#{butt}`"
+        else
+          butt
         end
       end
 

--- a/spec/lita/handlers/butt_spec.rb
+++ b/spec/lita/handlers/butt_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 describe Lita::Handlers::Butt, lita_handler: true do
   subject { described_class.new(robot) }
 
-  it { is_expected.to route('butt').to(:butt) }
-  it { is_expected.to route('btt').to(:butt) }
-  it { is_expected.to route('buuuuuutt').to(:butt) }
+  it { is_expected.to route('butt').to :butt }
+  it { is_expected.to route('btt').to :butt }
+  it { is_expected.to route('buuuuuutt').to :butt }
 
+  it { is_expected.to route('butts').to :butt }
+  it { is_expected.to route('btts').to :butt }
+  it { is_expected.to route('buuuuuutts').to :butt }
   describe '#butt' do
     it 'replies with a butt' do
       send_message 'butt'
@@ -31,6 +34,12 @@ describe Lita::Handlers::Butt, lita_handler: true do
     it 'replies with multiple big butts' do
       send_message 'buuuuutts'
       expect(replies.last).to eq '(_____)_____) (_____)_____)'
+    end
+  end
+
+  describe '#escape' do
+    it 'escapes a Slack butt' do
+      expect(subject.escape(subject.make_butt, :slack)).to eq '`(_)_)`'
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where a chat service interprets `_)_` as a desire to
emphasize the buttcrack. As much as the emphasis on the butt _should_ be
on the butt crack, it makes our ASCII butts look funny.

I'd add other chat services, like Hipchat, but I have no idea how they
do code formatting. `¯\_(ツ)_/¯`

I also refactored butt-making into its own method to make it all easier
to test.